### PR TITLE
Default content-type origin request to response

### DIFF
--- a/config.json
+++ b/config.json
@@ -61,6 +61,17 @@
 					"Password": "your_password"
 				}
 			}]
+		},{
+			"listenPath": "/go/image",
+			"headerName": "environment",
+			"DefaultForwardPath": {
+				"path": "https://golang.org/doc/gopher/frontpage.png",
+				"ContentType": "text/html",
+				"BasicAuth": {
+					"Username": "your_username",
+					"Password": "your_password"
+				}
+			}
 		}]
 	}
 }

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 )
 
 type JsonRoot struct {
@@ -91,7 +92,12 @@ func HttpHandler(w http.ResponseWriter, r *http.Request, router Router) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	CheckErr(err)
-	fmt.Fprintf(w, string(body))
+
+	//resp with original Content-Type
+	headerResp := strings.Join(resp.Header["Content-Type"], "")
+	w.Header().Set("Content-Type", headerResp)
+	w.Write([]byte(body))
+	// fmt.Fprintf(w, string(body))
 
 }
 


### PR DESCRIPTION
Return the api gateway the same return content-type of the request to path. In config.json I add the exemple of go image.